### PR TITLE
Fix random_gates

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ def random_noise_gate(n_qubits: int) -> Any:
 
 
 @pytest.fixture
-def random_noisy_protocol() -> Any:
+def random_noisy_protocol(n_qubits: int, target: int) -> Any:
     noise_type = random.choice(list(DigitalNoiseType))
     if noise_type == DigitalNoiseType.PAULI_CHANNEL:
         noise_prob = torch.rand(size=(3,))
@@ -196,6 +196,15 @@ def random_noisy_protocol() -> Any:
         noise_prob = torch.rand(size=(2,))
     else:
         noise_prob = torch.rand(size=(1,)).item()
+
+    # Set the target for two-qubit noise protocols
+    if noise_type in [
+        DigitalNoiseType.TWO_QUBIT_DEPHASING,
+        DigitalNoiseType.TWO_QUBIT_DEPOLARIZING,
+    ]:
+        control = random.choice([i for i in range(n_qubits) if i != target])
+        noise_target: int | tuple[int, int] = (control, target)
+        return DigitalNoiseProtocol(noise_type, noise_prob, target=noise_target)
     return DigitalNoiseProtocol(noise_type, noise_prob)
 
 
@@ -209,18 +218,27 @@ def random_noisy_unitary_gate(
     ROTATION_GATES = [RX, RY, RZ, PHASE]
     CONTROLLED_GATES = [CNOT, CY, CZ]
     ROTATION_CONTROL_GATES = [CRX, CRY, CRZ, CPHASE]
-    UNITARY_GATES = (
-        SINGLE_GATES + ROTATION_GATES + CONTROLLED_GATES + ROTATION_CONTROL_GATES
+    UNITARY_GATES: list[
+        type[ControlledRotationGate | ControlledPrimitive | Parametric | Primitive]
+    ] = (SINGLE_GATES + ROTATION_GATES + CONTROLLED_GATES + ROTATION_CONTROL_GATES)
+    control = random.choice([i for i in range(n_qubits) if i != target])
+    is_two_qubit_noise = (
+        random_noisy_protocol.noise_instances[0].type
+        == DigitalNoiseType.TWO_QUBIT_DEPHASING
+        or random_noisy_protocol.noise_instances[0].type
+        == DigitalNoiseType.TWO_QUBIT_DEPOLARIZING
     )
-    if (
-        random_noisy_protocol == DigitalNoiseType.TWO_QUBIT_DEPHASING
-        or random_noisy_protocol == DigitalNoiseType.TWO_QUBIT_DEPOLARIZING
-    ):
+    if is_two_qubit_noise:
         # For two-qubit noise protocols, we only two qubit gates
         UNITARY_GATES = CONTROLLED_GATES + ROTATION_CONTROL_GATES
+        control = random_noisy_protocol.target[0]  # type: ignore[union-attr]
     unitary_gate = random.choice(UNITARY_GATES)
     protocol_gates, protocol_info = random_noisy_protocol.gates[0]
-    noise_gate = protocol_gates(target, protocol_info.error_probability)
+
+    if is_two_qubit_noise:
+        noise_gate = protocol_gates((control, target), protocol_info.error_probability)  # type: ignore[call-arg]
+    else:
+        noise_gate = protocol_gates(target, protocol_info.error_probability)
     if unitary_gate in SINGLE_GATES:
         return (
             unitary_gate(target=target, noise=random_noisy_protocol),  # type: ignore[call-arg]
@@ -236,16 +254,12 @@ def random_noisy_unitary_gate(
             noise_gate,
         )
     if unitary_gate in CONTROLLED_GATES:
-        control = random.choice([i for i in range(n_qubits) if i != target])
-        noise_gate.target = (control, target)
         return (
             unitary_gate(control=control, target=target, noise=random_noisy_protocol),  # type: ignore[call-arg]
             unitary_gate(control=control, target=target),  # type: ignore[call-arg]
             noise_gate,
         )
     if unitary_gate in ROTATION_CONTROL_GATES:
-        control = random.choice([i for i in range(n_qubits) if i != target])
-        noise_gate.target = (control, target)
         return (
             unitary_gate(
                 control=control,


### PR DESCRIPTION
This pull request refactors and enhances the testing utilities in `tests/conftest.py` to better support two-qubit noise protocols and streamline the handling of noise and unitary gate definitions. Key changes include adding parameters for noise target specification, improving type annotations, and refining logic for two-qubit noise handling.

### Enhancements to noise protocol generation:

* [`random_noisy_protocol`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L188-R188): Added `n_qubits` and `target` parameters to allow specifying the target qubit and generating two-qubit noise protocols with appropriate control-target pairs. This ensures more accurate and flexible noise protocol creation. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L188-R188) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R199-R207)

### Improvements to unitary gate generation:

* [`random_noisy_unitary_gate`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L212-R240): Refactored logic to handle two-qubit noise protocols explicitly by checking noise type and dynamically adjusting the unitary gate selection and noise gate creation. Added type annotations for `UNITARY_GATES` and removed redundant control-target selection logic. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L212-R240) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L239-L248)